### PR TITLE
document.body.toggleClass is not a function

### DIFF
--- a/src/js/plugins/grid.js
+++ b/src/js/plugins/grid.js
@@ -38,7 +38,7 @@ export default class Grid {
    */
   onKeyPress_(event) {
     if (event.which === Keys.ENTER) {
-      document.body.toggleClass('baseline');
+      document.body.classList.toggle('baseline');
     }
   }
 }


### PR DESCRIPTION
In a form like this https://webslides.tv/demos/components#slide=92
when you press enter to submit the form, Chrome 56 throws an exception:

```
Uncaught TypeError: document.body.toggleClass is not a function
    at Grid.onKeyPress_ (webslides.js:984)
onKeyPress_ @ webslides.js:984
```
in this line you try to toggle body class with:
```
document.body.toggleClass('baseline');
```
but the function is not defined...

I think that the correct function is `classList.toggle("..")`

Also when you add the class to the body, the associated style try to load an image which doesn't exists:
```
body.baseline {
  background: url(../images/baseline.png) left top .8rem/.8rem;
}
```

throws this error:

```
GET https://webslides.tv/images/baseline.png 404 (Not Found)
```